### PR TITLE
Add pytest tests for grade extraction

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ google-auth-oauthlib
 google-api-python-client
 numpy
 streamlit-aggrid>=0.4.0
+pytest

--- a/tests/test_extract_primary_grade.py
+++ b/tests/test_extract_primary_grade.py
@@ -1,0 +1,14 @@
+import os
+import sys
+import pytest
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from config import extract_primary_grade_from_full_value
+
+@pytest.mark.parametrize("value,expected", [
+    ("F | 0, CR | 3", "CR | 3"),
+    ("B- | 0, A | 3", "A | 3"),
+])
+def test_extract_primary_grade(value, expected):
+    assert extract_primary_grade_from_full_value(value) == expected
+


### PR DESCRIPTION
## Summary
- ensure `pytest` is available by adding it to requirements
- create test for `extract_primary_grade_from_full_value`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68401c1e7a00832b88f269bc475a2de5