### PR TITLE
Fix typo in calculate_credits docstring

### DIFF
--- a/data_processing.py
+++ b/data_processing.py
@@ -232,7 +232,7 @@ def determine_course_value(grade: str, course: str, courses_dict: dict, rules_li
 def calculate_credits(row: pd.Series, courses_dict: dict):
     """
     Calculates Completed, Registered, Remaining, Total Credits.
-    - If any "CR" appears in a multi‐attemp cell → count as Registered (not Completed).
+    - If any "CR" appears in a multi‐attempt cell → count as Registered (not Completed).
     - If any token has numeric > 0 or PASS → count as Completed.
     - Else → Remaining.
     """


### PR DESCRIPTION
## Summary
- correct spelling of "multi-attempt" in `calculate_credits` docstring

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68401c212d7c832ba00ab34a570a323d