### PR TITLE
Show CR registrations as cr in completion toggle

### DIFF
--- a/pages/3_View_Reports.py
+++ b/pages/3_View_Reports.py
@@ -143,9 +143,11 @@ if show_complete_toggle:
     def collapse_pass_fail(val):
         if not isinstance(val, str):
             return val
-        parts = val.split("|")
+        parts = [p.strip() for p in val.split("|")]
+        if parts and parts[0].upper() == "CR":
+            return "cr"
         if len(parts) == 2:
-            credit_str = parts[1].strip()
+            credit_str = parts[1]
             try:
                 return "c" if int(credit_str) > 0 else ""
             except ValueError:


### PR DESCRIPTION
## Summary
- update the collapse_pass_fail helper to detect CR statuses
- surface CR registrations as `cr` instead of being converted to completed

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_6903906541ec832b95ac88047754669b