### PR TITLE
Fix completion toggle color coding

### DIFF
--- a/completion_utils.py
+++ b/completion_utils.py
@@ -1,0 +1,27 @@
+"""Utilities for normalizing grade values in completion views."""
+
+
+def collapse_pass_fail_value(val):
+    """Normalize grade strings to completion shorthand for the toggle view."""
+    if not isinstance(val, str):
+        return val
+
+    parts = [p.strip() for p in val.split("|")]
+    if parts and parts[0].upper() == "CR":
+        return "cr"
+
+    if len(parts) == 1 and parts[0].upper() == "NR":
+        return "nc"
+
+    if len(parts) == 2:
+        credit_str = parts[1]
+        try:
+            return "c" if int(credit_str) > 0 else "nc"
+        except ValueError:
+            normalized_credit = credit_str.upper()
+            if normalized_credit == "PASS":
+                return "c"
+            if normalized_credit == "FAIL":
+                return "nc"
+
+    return val

--- a/config.py
+++ b/config.py
@@ -49,13 +49,25 @@ is_passing_grade = is_passing_grade_from_list
 def cell_color(value: str) -> str:
     """
     Applies background colors for cells showing one or more
-    'GRADE | credit' entries (comma-separated):
-      - If ANY entry starts with "CR", show pale yellow.
-      - Else if ANY entry has credit > 0 or credit token "PASS", show light green.
-      - Otherwise show pink.
+    'GRADE | credit' entries (comma-separated).
+
+    Collapsed completion toggle values ("c", "cr", "nc") map directly to their
+    associated colors, while the legacy "GRADE | credit" strings retain the
+    previous logic:
+      - Any "CR" entry ⇒ pale yellow.
+      - Any passing credit (>0 or "PASS") ⇒ light green.
+      - Otherwise ⇒ pink.
     """
     if not isinstance(value, str):
         return ""
+
+    collapsed = value.strip().lower()
+    if collapsed == "c":
+        return "background-color: lightgreen"
+    if collapsed == "cr":
+        return "background-color: #FFFACD"
+    if collapsed == "nc":
+        return "background-color: pink"
 
     # Split into individual entries like "F | 0" and "C- | 3"
     entries = [e.strip() for e in value.split(",") if e.strip()]

--- a/pages/3_View_Reports.py
+++ b/pages/3_View_Reports.py
@@ -18,6 +18,7 @@ from config import (
     extract_primary_grade_from_full_value,
     cell_color
 )
+from completion_utils import collapse_pass_fail_value
 
 st.title("View Reports")
 st.markdown("---")
@@ -137,20 +138,11 @@ else:
 show_complete_toggle = st.checkbox(
     "Show Completed/Not Completed Only",
     value=False,
-    help="If enabled, displays 'c' for passed courses and blank for not passed."
+    help="If enabled, displays 'c' for passed courses, 'cr' for current registrations, and 'nc' for not completed."
 )
 if show_complete_toggle:
     def collapse_pass_fail(val):
-        if not isinstance(val, str):
-            return val
-        parts = val.split("|")
-        if len(parts) == 2:
-            credit_str = parts[1].strip()
-            try:
-                return "c" if int(credit_str) > 0 else ""
-            except ValueError:
-                return "c" if credit_str.upper() == "PASS" else ""
-        return val
+        return collapse_pass_fail_value(val)
 
     for course in target_courses:
         displayed_req_df[course] = displayed_req_df[course].apply(collapse_pass_fail)

--- a/tests/test_cell_color.py
+++ b/tests/test_cell_color.py
@@ -1,0 +1,27 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from config import cell_color  # noqa: E402
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        ("c", "background-color: lightgreen"),
+        ("cr", "background-color: #FFFACD"),
+        ("nc", "background-color: pink"),
+        (" C ", "background-color: lightgreen"),
+        ("CR | 3", "background-color: #FFFACD"),
+    ],
+)
+def test_cell_color_collapsed_and_full_values(value, expected):
+    assert cell_color(value) == expected
+
+
+def test_cell_color_non_string_returns_blank():
+    assert cell_color(None) == ""

--- a/tests/test_collapse_pass_fail.py
+++ b/tests/test_collapse_pass_fail.py
@@ -1,0 +1,39 @@
+import sys
+from pathlib import Path
+
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from completion_utils import collapse_pass_fail_value  # noqa: E402
+
+
+def test_collapse_pass_fail_marks_completed_credit_courses():
+    assert collapse_pass_fail_value("A | 3") == "c"
+
+
+def test_collapse_pass_fail_marks_zero_credit_as_not_completed():
+    assert collapse_pass_fail_value("B | 0") == "nc"
+
+
+def test_collapse_pass_fail_marks_zero_credit_fail_token():
+    assert collapse_pass_fail_value("C | FAIL") == "nc"
+
+
+def test_collapse_pass_fail_marks_pass_token():
+    assert collapse_pass_fail_value("D | PASS") == "c"
+
+
+def test_collapse_pass_fail_marks_current_registration():
+    assert collapse_pass_fail_value("CR | PASS") == "cr"
+
+
+def test_collapse_pass_fail_marks_nr_shorthand():
+    assert collapse_pass_fail_value("NR") == "nc"
+
+
+def test_collapse_pass_fail_leaves_unexpected_formats():
+    assert collapse_pass_fail_value("In Progress") == "In Progress"
+
+
+def test_collapse_pass_fail_passthrough_non_string():
+    assert collapse_pass_fail_value(None) is None


### PR DESCRIPTION
## Summary
- update the `cell_color` helper to map collapsed completion values to the expected colors
- add regression tests covering the color mapping for collapsed and legacy grade strings

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_6903906541ec832b95ac88047754669b