### PR TITLE
Prioritize completed attempts when extracting primary grade

### DIFF
--- a/tests/test_extract_primary_grade.py
+++ b/tests/test_extract_primary_grade.py
@@ -5,10 +5,14 @@ import pytest
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 from config import extract_primary_grade_from_full_value
 
-@pytest.mark.parametrize("value,expected", [
-    ("F | 0, CR | 3", "CR | 3"),
-    ("B- | 0, A | 3", "A | 3"),
-])
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        ("F | 0, CR | 3", "CR | 3"),
+        ("B- | 0, A | 3", "A | 3"),
+        ("R | FAIL, P | PASS", "P | PASS"),
+    ],
+)
 def test_extract_primary_grade(value, expected):
     assert extract_primary_grade_from_full_value(value) == expected
 


### PR DESCRIPTION
## Summary
- ensure extract_primary_grade_from_full_value prefers clearly completed attempts after existing CR and grade order checks
- preserve original entry formatting when selecting the prioritized grade
- add regression coverage for pass/fail combinations that should now prefer the passing attempt

## Testing
- pytest tests/test_extract_primary_grade.py

------
https://chatgpt.com/codex/tasks/task_e_69066822be68832b8cf11995f691727d