### PR TITLE
Ensure intensive roster retains students without entries

### DIFF
--- a/data_processing.py
+++ b/data_processing.py
@@ -188,6 +188,10 @@ def process_progress_report(
         axis=1
     )
 
+    # Capture the full student roster before splitting, so joins can retain
+    # students even if they lack rows in a particular category (e.g., intensive).
+    roster_df = df[["ID", "NAME"]].drop_duplicates()
+
     # 4) Split into required, intensive, extra
     extra_courses_df = df[
         (~df["Mapped Course"].isin(target_courses.keys())) &
@@ -210,6 +214,10 @@ def process_progress_report(
         values="ProcessedValue",
         aggfunc=lambda vals: ", ".join(vals)
     ).reset_index()
+
+    # Ensure the intensive table retains all students from the original roster,
+    # even if they lack intensive course entries.
+    intensive_pivot_df = roster_df.merge(intensive_pivot_df, on=["ID", "NAME"], how="left")
 
     # 6) Fill missing columns with "NR"
     for course in target_courses:

--- a/tests/test_process_progress_report.py
+++ b/tests/test_process_progress_report.py
@@ -1,0 +1,61 @@
+import pandas as pd
+
+from data_processing import process_progress_report
+
+
+def test_intensive_results_include_students_without_intensive_rows():
+    df = pd.DataFrame(
+        [
+            {
+                "ID": "123",
+                "NAME": "Alice Example",
+                "Course": "REQ101",
+                "Grade": "A",
+                "Year": "2023",
+                "Semester": "Fall",
+            }
+        ]
+    )
+
+    target_courses = {"REQ101": 3}
+    intensive_courses = {"INT101": 0, "INT202": 0}
+    target_rules = {
+        "REQ101": [
+            {
+                "Credits": 3,
+                "PassingGrades": "A,B",
+                "FromOrd": 0,
+                "ToOrd": 99,
+            }
+        ]
+    }
+    intensive_rules = {
+        "INT101": [
+            {
+                "Credits": 0,
+                "PassingGrades": "P",
+                "FromOrd": 0,
+                "ToOrd": 99,
+            }
+        ],
+        "INT202": [
+            {
+                "Credits": 0,
+                "PassingGrades": "P",
+                "FromOrd": 0,
+                "ToOrd": 99,
+            }
+        ],
+    }
+
+    _, intensive_df, _, _ = process_progress_report(
+        df,
+        target_courses,
+        intensive_courses,
+        target_rules,
+        intensive_rules,
+    )
+
+    assert list(intensive_df.columns) == ["ID", "NAME", "INT101", "INT202"]
+    assert intensive_df.loc[0, "INT101"] == "NR"
+    assert intensive_df.loc[0, "INT202"] == "NR"


### PR DESCRIPTION
## Summary
- capture the full student roster before splitting required and intensive courses
- left join the intensive pivot to the roster so students without intensive rows still appear
- add regression coverage confirming intensive columns default to "NR" when missing

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_69075b813d78832b9de248cc9f36b115