### PR TITLE
Ensure required table includes all students

### DIFF
--- a/data_processing.py
+++ b/data_processing.py
@@ -215,8 +215,9 @@ def process_progress_report(
         aggfunc=lambda vals: ", ".join(vals)
     ).reset_index()
 
-    # Ensure the intensive table retains all students from the original roster,
-    # even if they lack intensive course entries.
+    # Ensure the required and intensive tables retain all students from the original
+    # roster, even if they lack rows in a particular category.
+    pivot_df = roster_df.merge(pivot_df, on=["ID", "NAME"], how="left")
     intensive_pivot_df = roster_df.merge(intensive_pivot_df, on=["ID", "NAME"], how="left")
 
     # 6) Fill missing columns with "NR"

--- a/tests/test_process_progress_report.py
+++ b/tests/test_process_progress_report.py
@@ -59,3 +59,61 @@ def test_intensive_results_include_students_without_intensive_rows():
     assert list(intensive_df.columns) == ["ID", "NAME", "INT101", "INT202"]
     assert intensive_df.loc[0, "INT101"] == "NR"
     assert intensive_df.loc[0, "INT202"] == "NR"
+
+
+def test_required_results_include_students_without_required_rows():
+    df = pd.DataFrame(
+        [
+            {
+                "ID": "123",
+                "NAME": "Alice Example",
+                "Course": "INT101",
+                "Grade": "P",
+                "Year": "2023",
+                "Semester": "Fall",
+            },
+            {
+                "ID": "456",
+                "NAME": "Bob Example",
+                "Course": "REQ101",
+                "Grade": "A",
+                "Year": "2023",
+                "Semester": "Fall",
+            },
+        ]
+    )
+
+    target_courses = {"REQ101": 3}
+    intensive_courses = {"INT101": 0}
+    target_rules = {
+        "REQ101": [
+            {
+                "Credits": 3,
+                "PassingGrades": "A,B",
+                "FromOrd": 0,
+                "ToOrd": 99,
+            }
+        ]
+    }
+    intensive_rules = {
+        "INT101": [
+            {
+                "Credits": 0,
+                "PassingGrades": "P",
+                "FromOrd": 0,
+                "ToOrd": 99,
+            }
+        ]
+    }
+
+    required_df, _, _, _ = process_progress_report(
+        df,
+        target_courses,
+        intensive_courses,
+        target_rules,
+        intensive_rules,
+    )
+
+    assert list(required_df.columns) == ["ID", "NAME", "REQ101"]
+    alice_row = required_df[required_df["ID"] == "123"].iloc[0]
+    assert alice_row["REQ101"] == "NR"


### PR DESCRIPTION
## Summary
- ensure the required-course pivot is merged with the full roster so every student appears in the required table
- add a regression test that verifies students without required rows receive NR entries

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_690761151fd0832bb44705c68e42a4d3